### PR TITLE
fix: deprecated `require.extensions` could be `undefined`

### DIFF
--- a/.changeset/wise-hornets-cross.md
+++ b/.changeset/wise-hornets-cross.md
@@ -2,4 +2,4 @@
 "@pkgr/core": patch
 ---
 
-fix `undefined` type in deprecated required extensions
+fix: deprecated `require.extensions` could be `undefined`

--- a/.changeset/wise-hornets-cross.md
+++ b/.changeset/wise-hornets-cross.md
@@ -1,0 +1,5 @@
+---
+"@pkgr/core": patch
+---
+
+fix `undefined` type in deprecated required extensions

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -9,5 +9,11 @@ export interface CjsRequire extends NodeJS.Require {
 export const cjsRequire: CjsRequire =
   typeof require === 'function' ? require : createRequire(import.meta.url)
 
-// eslint-disable-next-line sonarjs/deprecation
-export const EXTENSIONS = ['.ts', '.tsx', ...Object.keys(cjsRequire.extensions || {})]
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, sonarjs/deprecation
+const DEFAULT_EXTENSIONS = cjsRequire.extensions
+  ? // eslint-disable-next-line sonarjs/deprecation
+    Object.keys(cjsRequire.extensions)
+  : // `require.extensions` could be `undefined` - #430
+    ['.js', '.json', '.node']
+
+export const EXTENSIONS = ['.ts', '.tsx', ...DEFAULT_EXTENSIONS]

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -10,4 +10,4 @@ export const cjsRequire: CjsRequire =
   typeof require === 'function' ? require : createRequire(import.meta.url)
 
 // eslint-disable-next-line sonarjs/deprecation
-export const EXTENSIONS = ['.ts', '.tsx', ...Object.keys(cjsRequire.extensions)]
+export const EXTENSIONS = ['.ts', '.tsx', ...Object.keys(cjsRequire.extensions || {})]


### PR DESCRIPTION
Hi @JounQin 

We recently encountered an issue when using eslint-plugin-prettier with eslint 10 and yarn PnP.

It seems after the package is converted to esm format, some of the deprecated settings in this project caused a bug.

In nodejs require.extensions is deprecated. More specifically the require.extensions now becomes undefined, and cannot be passed into the Object.keys function. 

This merge request quickly fixes https://github.com/un-ts/pkgr/issues/430

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of file-extension handling to prevent runtime errors when extension metadata is unavailable, increasing stability across diverse runtime environments and setups.

* **Chores**
  * Added a patch release entry documenting the fix and bumping the package release to reflect the update.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/un-ts/pkgr/pull/433?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->