### PR TITLE
feat(utils): support default export in tryRequirePkg

### DIFF
--- a/.changeset/soft-rivers-travel.md
+++ b/.changeset/soft-rivers-travel.md
@@ -1,0 +1,5 @@
+---
+"@pkgr/utils": minor
+---
+
+Add a `preferDefault` option to `tryRequirePkg` for resolving default exports.

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -5,9 +5,20 @@ import { isDynamicPattern, globSync } from 'tinyglobby'
 
 import { SCRIPT_RUNNERS, SCRIPT_EXECUTORS } from './constants.js'
 
-export const tryRequirePkg = <T>(pkg: string): T | undefined => {
+export const tryRequirePkg = <T>(
+  pkg: string,
+  preferDefault?: boolean,
+): T | undefined => {
   try {
-    return cjsRequire<T>(pkg)
+    const mod = cjsRequire(pkg)
+    return (
+      preferDefault &&
+      mod != null &&
+      typeof mod === 'object' &&
+      'default' in mod
+        ? mod.default
+        : mod
+    ) as T
   } catch {}
 }
 


### PR DESCRIPTION
## Summary
- add an optional `preferDefault` flag to `tryRequirePkg`
- return `mod.default` when requested and present, while preserving the existing fallback behavior

## Test
- `yarn lint:tsc`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated module import utility with optional parameter support for enhanced flexibility in module loading behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/un-ts/pkgr/pull/437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->