### PR TITLE
fix(core): use canonical repository metadata

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,11 @@
   "version": "0.3.6",
   "type": "module",
   "description": "Shared core module for `@pkgr` packages or any package else",
-  "repository": "git+https://github.com/un-ts/pkgr.git",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/un-ts/pkgr.git",
+    "directory": "packages/core"
+  },
   "homepage": "https://github.com/un-ts/pkgr/blob/master/packages/core",
   "author": "JounQin <admin@1stg.me> (https://www.1stG.me)",
   "funding": "https://opencollective.com/pkgr",


### PR DESCRIPTION
## Summary
- replace the string repository field with npm's object form
- identify packages/core as the monorepo package directory
- keep the existing repository URL unchanged

## Validation
- parsed packages/core/package.json and asserted repository.type, repository.url, and repository.directory
- npm.cmd pack --dry-run --ignore-scripts --json
- git diff --check

Publint no longer reports the repository shorthand warning. Its remaining local errors are the existing missing lib build artifacts because the package was checked before a build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package repository metadata configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->