### PR TITLE
fix: add homepage/bugs metadata to pkgr

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,5 +94,8 @@
     "ignoreNested": true,
     "strict": true,
     "update": true
+  },
+  "bugs": {
+    "url": "https://github.com/un-ts/pkgr/issues"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "description": "Simple but incredible utilities for package bundlers like rollup",
   "repository": "https://github.com/un-ts/pkgr.git",
   "homepage": "https://pkgr.1stG.me",
+  "bugs": {
+    "url": "https://github.com/un-ts/pkgr/issues"
+  },
   "author": "JounQin <admin@1stg.me> (https://www.1stG.me)",
   "license": "MIT",
   "private": true,
@@ -94,8 +97,5 @@
     "ignoreNested": true,
     "strict": true,
     "update": true
-  },
-  "bugs": {
-    "url": "https://github.com/un-ts/pkgr/issues"
   }
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -5,6 +5,9 @@
   "description": "Shared browser utils for `@pkgr` packages or any package else",
   "repository": "git+https://github.com/un-ts/pkgr.git",
   "homepage": "https://github.com/un-ts/pkgr/blob/master/packages/browser",
+  "bugs": {
+    "url": "https://github.com/un-ts/pkgr/issues"
+  },
   "author": "JounQin <admin@1stg.me> (https://www.1stG.me)",
   "funding": "https://opencollective.com/pkgr",
   "license": "MIT",
@@ -37,8 +40,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false,
-  "bugs": {
-    "url": "https://github.com/un-ts/pkgr/issues"
-  }
+  "sideEffects": false
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -37,5 +37,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "bugs": {
+    "url": "https://github.com/un-ts/pkgr/issues"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,9 @@
   "description": "Shared core module for `@pkgr` packages or any package else",
   "repository": "git+https://github.com/un-ts/pkgr.git",
   "homepage": "https://github.com/un-ts/pkgr/blob/master/packages/core",
+  "bugs": {
+    "url": "https://github.com/un-ts/pkgr/issues"
+  },
   "author": "JounQin <admin@1stg.me> (https://www.1stG.me)",
   "funding": "https://opencollective.com/pkgr",
   "license": "MIT",
@@ -34,8 +37,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false,
-  "bugs": {
-    "url": "https://github.com/un-ts/pkgr/issues"
-  }
+  "sideEffects": false
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,5 +34,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "bugs": {
+    "url": "https://github.com/un-ts/pkgr/issues"
+  }
 }

--- a/packages/es-modules/package.json
+++ b/packages/es-modules/package.json
@@ -5,6 +5,9 @@
   "description": "Union collections of es modules mappings for pkgs without or with incorrect `module` field",
   "repository": "git+https://github.com/un-ts/pkgr.git",
   "homepage": "https://github.com/un-ts/pkgr/blob/master/packages/es-modules",
+  "bugs": {
+    "url": "https://github.com/un-ts/pkgr/issues"
+  },
   "author": "JounQin <admin@1stg.me> (https://www.1stG.me)",
   "funding": "https://opencollective.com/pkgr",
   "license": "MIT",
@@ -38,8 +41,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false,
-  "bugs": {
-    "url": "https://github.com/un-ts/pkgr/issues"
-  }
+  "sideEffects": false
 }

--- a/packages/es-modules/package.json
+++ b/packages/es-modules/package.json
@@ -38,5 +38,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "bugs": {
+    "url": "https://github.com/un-ts/pkgr/issues"
+  }
 }

--- a/packages/imagemin/package.json
+++ b/packages/imagemin/package.json
@@ -46,5 +46,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "bugs": {
+    "url": "https://github.com/un-ts/pkgr/issues"
+  }
 }

--- a/packages/imagemin/package.json
+++ b/packages/imagemin/package.json
@@ -5,6 +5,9 @@
   "description": "Seamless imagemin API wrapper to minify images, working perfectly with lint-staged also",
   "repository": "git+https://github.com/un-ts/pkgr.git",
   "homepage": "https://github.com/un-ts/pkgr/blob/master/packages/imagemin",
+  "bugs": {
+    "url": "https://github.com/un-ts/pkgr/issues"
+  },
   "author": "JounQin <admin@1stg.me> (https://www.1stG.me)",
   "funding": "https://opencollective.com/pkgr",
   "license": "MIT",
@@ -46,8 +49,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false,
-  "bugs": {
-    "url": "https://github.com/un-ts/pkgr/issues"
-  }
+  "sideEffects": false
 }

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -55,5 +55,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "bugs": {
+    "url": "https://github.com/un-ts/pkgr/issues"
+  }
 }

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -5,6 +5,9 @@
   "description": "Seamless Rollup bundler wrapper for libraries",
   "repository": "git+https://github.com/un-ts/pkgr.git",
   "homepage": "https://github.com/un-ts/pkgr/blob/master/packages/rollup",
+  "bugs": {
+    "url": "https://github.com/un-ts/pkgr/issues"
+  },
   "author": "JounQin <admin@1stg.me> (https://www.1stG.me)",
   "funding": "https://opencollective.com/pkgr",
   "license": "MIT",
@@ -55,8 +58,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false,
-  "bugs": {
-    "url": "https://github.com/un-ts/pkgr/issues"
-  }
+  "sideEffects": false
 }

--- a/packages/umd-globals/package.json
+++ b/packages/umd-globals/package.json
@@ -35,5 +35,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "bugs": {
+    "url": "https://github.com/un-ts/pkgr/issues"
+  }
 }

--- a/packages/umd-globals/package.json
+++ b/packages/umd-globals/package.json
@@ -5,6 +5,9 @@
   "description": "Union collections of umd globals mappings",
   "repository": "git+https://github.com/un-ts/pkgr.git",
   "homepage": "https://github.com/un-ts/pkgr/blob/master/packages/umd-globals",
+  "bugs": {
+    "url": "https://github.com/un-ts/pkgr/issues"
+  },
   "author": "JounQin <admin@1stg.me> (https://www.1stG.me)",
   "funding": "https://opencollective.com/pkgr",
   "license": "MIT",
@@ -35,8 +38,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false,
-  "bugs": {
-    "url": "https://github.com/un-ts/pkgr/issues"
-  }
+  "sideEffects": false
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,6 +5,9 @@
   "description": "Shared utils for `@pkgr` packages or any package else",
   "repository": "git+https://github.com/un-ts/pkgr.git",
   "homepage": "https://github.com/un-ts/pkgr/blob/master/packages/utils",
+  "bugs": {
+    "url": "https://github.com/un-ts/pkgr/issues"
+  },
   "author": "JounQin <admin@1stg.me> (https://www.1stG.me)",
   "funding": "https://opencollective.com/pkgr",
   "license": "MIT",
@@ -35,8 +38,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false,
-  "bugs": {
-    "url": "https://github.com/un-ts/pkgr/issues"
-  }
+  "sideEffects": false
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -35,5 +35,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "bugs": {
+    "url": "https://github.com/un-ts/pkgr/issues"
+  }
 }


### PR DESCRIPTION
Closes Charles micro-bounty #1523

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package metadata across all project packages to include a standardized bug reporting URL, directing users to the GitHub issues page for submitting reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->